### PR TITLE
Give an example of browserSync with artisan serve

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -340,7 +340,15 @@ https://cdn.example.com/js/app.js?id=1964becbdd96414518cd
 mix.browserSync('laravel.test');
 ```
 
-[BrowserSync options](https://browsersync.io/docs/options) may be specified by passing a JavaScript object to the `browserSync` method:
+Or if you're using `artisan serve`, like so:
+
+```js
+mix.browserSync({
+    proxy: 'localhost:8000'
+});
+```
+
+[BrowserSync options](https://browsersync.io/docs/options) may be specified by passing a JavaScript object to the `browserSync` method in the same way:
 
 ```js
 mix.browserSync({


### PR DESCRIPTION
The documentation states that the most common method for invoking for Laravel is `artisan serve`, yet the documentation example for `browserSync()` will not work with that. This gives an example where the user can get `browserSync` up and running quickly and easily.